### PR TITLE
Drop exact Node 22.0.0 from release matrix

### DIFF
--- a/.github/WORKFLOWS.md
+++ b/.github/WORKFLOWS.md
@@ -25,7 +25,7 @@ This directory contains the GitHub Actions workflows and configuration for autom
 
 **Extended Test Matrix:**
 - **Operating Systems**: Ubuntu 22.04/24.04, Windows 2022/latest, macOS 14/latest
-- **Node.js Versions**: 20.9.0, 20.x, 22.0.0, 22.x
+- **Node.js Versions**: 20.9.0, 20.x, 22.x
 - **Electron Versions**: 25.0.0-30.0.0 (comprehensive range testing)
 
 **Jobs:**

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-22.04, ubuntu-24.04, windows-2022, windows-latest, macos-14, macos-latest]
-        node-version: [20.9.0, 20.x, 22.0.0, 22.x]
+        node-version: [20.9.0, 20.x, 22.x]
         
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Summary
- remove exact Node 22.0.0 from release workflow matrix
- keep Node 22.x coverage and exact Node 20.9.0 coverage
- update workflow docs

## Reason
Windows runners can restore an npm cache that breaks the Node 22.0.0 npm shim, causing npm ci to fail before project tests run.