### PR TITLE
ci: harden required check, drop EOL Node 20, remove dead steps

### DIFF
--- a/.github/WORKFLOWS.md
+++ b/.github/WORKFLOWS.md
@@ -9,7 +9,7 @@ This directory contains the GitHub Actions workflows and configuration for autom
 
 **Test Matrix:**
 - **Operating Systems**: Ubuntu, Windows, macOS
-- **Node.js Versions**: 20.x, 22.x
+- **Node.js Versions**: 22.x, 24.x
 - **Total Combinations**: 6 OS/Node combinations
 
 **Jobs:**
@@ -25,7 +25,7 @@ This directory contains the GitHub Actions workflows and configuration for autom
 
 **Extended Test Matrix:**
 - **Operating Systems**: Ubuntu 22.04/24.04, Windows 2022/latest, macOS 14/latest
-- **Node.js Versions**: 20.9.0, 20.x, 22.x
+- **Node.js Versions**: 22.12.0, 22.x, 24.x
 - **Electron Versions**: 25.x through 43.x, sampled every third major
 
 **Jobs:**
@@ -70,8 +70,9 @@ The CI system provides comprehensive test coverage across:
 - ✅ **macOS** (14, latest) - macOS compatibility
 
 ### **Node.js Compatibility**
-- ✅ **Node 20.x** (LTS) - Current LTS
-- ✅ **Node 22.x** (Current) - Latest features
+- ✅ **Node 22.x** - Maintenance LTS
+- ✅ **Node 24.x** - Active LTS
+- ⛔ **Node 20.x** - Dropped; reached end-of-life April 2026
 
 ### **Electron Compatibility**
 - ✅ **Electron 25.x-43.x** - Peer floor through current latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,9 +20,12 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        # Node 18.x removed: Jest 30 requires os.availableParallelism() (Node >= 20).
-        # The library itself is compatible with Node 18+ but can't run tests on it.
-        node-version: [20.x, 22.x]
+        # Maintenance LTS + Active LTS. Node 20 was dropped after it reached
+        # end-of-life in April 2026; testing an unsupported runtime told us
+        # nothing while delaying every PR.
+        # Floor note: Jest 30 needs os.availableParallelism(), so the test suite
+        # cannot run below Node 20 even though the library itself supports 18+.
+        node-version: [22.x, 24.x]
         
     steps:
       - name: Checkout code
@@ -56,7 +59,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: '20.x'
+          node-version: '24.x'
           cache: 'npm'
           
       - name: Install dependencies
@@ -96,7 +99,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: '20.x'
+          node-version: '24.x'
           cache: 'npm'
           
       - name: Install dependencies
@@ -104,13 +107,6 @@ jobs:
         
       - name: Run security audit
         run: npm audit --audit-level=moderate
-        continue-on-error: true
-        
-      - name: Check for known vulnerabilities
-        run: |
-          if command -v npx >/dev/null 2>&1; then
-            npx audit-ci --config-type audit-resolve.json || echo "No critical vulnerabilities found"
-          fi
         continue-on-error: true
 
   test-electron-compatibility:
@@ -133,7 +129,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: '20.x'
+          node-version: '24.x'
           cache: 'npm'
 
       - name: Install dependencies
@@ -169,7 +165,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: '20.x'
+          node-version: '24.x'
           cache: 'npm'
           
       - name: Install dependencies
@@ -234,19 +230,35 @@ jobs:
             }
           "
 
+  # This job is the single required status check in branch protection on main.
+  # Keep the name "Build and Test" stable — renaming it silently disables the
+  # gate, because branch protection matches required checks by name.
+  #
+  # It previously depended on [test] alone, which left lint, package validation
+  # and Electron compatibility ungated: a PR breaking any of them could merge.
+  # It now aggregates every job whose failure should block a merge.
   build-and-test:
     name: Build and Test
     runs-on: ubuntu-latest
-    needs: [test]
+    needs: [test, lint-and-format, test-electron-compatibility, package-validation]
     if: always()
     steps:
-      - name: Check test results
-        if: needs.test.result != 'success'
+      - name: Check upstream job results
         run: |
-          echo "Tests failed"
-          exit 1
-      - name: All tests passed
-        run: echo "All tests passed"
+          status=0
+          check() {
+            if [[ "$2" != "success" ]]; then
+              echo "FAILED: $1 ($2)"
+              status=1
+            else
+              echo "ok: $1"
+            fi
+          }
+          check "test"                       "${{ needs.test.result }}"
+          check "lint-and-format"            "${{ needs.lint-and-format.result }}"
+          check "test-electron-compatibility" "${{ needs.test-electron-compatibility.result }}"
+          check "package-validation"         "${{ needs.package-validation.result }}"
+          exit $status
 
   results-summary:
     name: Results Summary
@@ -297,7 +309,7 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "**Test Matrix Coverage:**" >> $GITHUB_STEP_SUMMARY
           echo "- **Operating Systems**: Ubuntu, Windows, macOS" >> $GITHUB_STEP_SUMMARY
-          echo "- **Node.js Versions**: 20.x, 22.x" >> $GITHUB_STEP_SUMMARY
+          echo "- **Node.js Versions**: 22.x, 24.x" >> $GITHUB_STEP_SUMMARY
           echo "- **Electron Versions**: 25.x (peer floor), 39.x (dev target), 43.x (latest)" >> $GITHUB_STEP_SUMMARY
           echo "- **Total Test Combinations**: 19 (6 OS/Node + 9 OS/Electron + 4 validation jobs)" >> $GITHUB_STEP_SUMMARY
           

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,9 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-22.04, ubuntu-24.04, windows-2022, windows-latest, macos-14, macos-latest]
-        node-version: [20.9.0, 20.x, 22.x]
+        # Pinned floor + both supported LTS lines. Node 20 dropped at its
+        # April 2026 end-of-life; 22.12.0 is the first 22.x LTS release.
+        node-version: [22.12.0, 22.x, 24.x]
         
     steps:
       - name: Checkout code
@@ -97,7 +99,7 @@ jobs:
           "40.x",
           "43.x"   # current latest
         ]
-        node-version: ["20.x"]
+        node-version: ["24.x"]
         
     steps:
       - name: Checkout code
@@ -115,15 +117,20 @@ jobs:
           npm ci --ignore-scripts
           
       - name: Install specific Electron version
+        # --ignore-scripts skips the postinstall binary download (~100MB per
+        # leg). This job only typechecks against the bundled electron.d.ts;
+        # nothing here executes Electron.
         run: |
-          npm install --save-dev electron@${{ matrix.electron-version }}
-          
-      - name: Display Electron version info
-        run: |
-          npx electron --version
-          node -e "console.log('Node in Electron:', process.versions.node)"
-        continue-on-error: true
-        
+          npm install --save-dev --ignore-scripts electron@${{ matrix.electron-version }}
+
+      # Removed: a "Display Electron version info" step that ran
+      # `npx electron --version`. It aborted on every Linux leg because
+      # chrome-sandbox must be owned by root with mode 4755, which npm install
+      # cannot set — emitting a failure annotation on each ubuntu run despite
+      # continue-on-error keeping the job green. Its second line also ran plain
+      # Node, so it reported the runner's Node version while labelling it
+      # "Node in Electron".
+
       - name: Run build with specific Electron
         run: npm run build
         
@@ -144,7 +151,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: '20.x'
+          node-version: '24.x'
           cache: 'npm'
           
       - name: Install dependencies
@@ -213,7 +220,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: '20.x'
+          node-version: '24.x'
           cache: 'npm'
           
       - name: Install dependencies
@@ -261,7 +268,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: '20.x'
+          node-version: '24.x'
           cache: 'npm'
           
       - name: Install dependencies

--- a/.github/workflows/security-monitoring.yml
+++ b/.github/workflows/security-monitoring.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: '20.x'
+          node-version: '24.x'
           cache: 'npm'
 
       - name: Install dependencies
@@ -279,7 +279,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: '20.x'
+          node-version: '24.x'
           cache: 'npm'
 
       - name: Install dependencies

--- a/.npmignore
+++ b/.npmignore
@@ -28,6 +28,7 @@ docs/
 examples/
 PORTING.md
 CLAUDE.md
+AGENTS.md
 PLAN-*.md
 ISSUE-*.md
 


### PR DESCRIPTION
Follow-up hygiene pass after #23. Also fixes the failure annotations seen on the manually-dispatched `release.yml` run.

## 1. The required status check was under-gating ⚠️

Branch protection on `main` requires exactly one check — **`Build and Test`** — and that job depended on `[test]` alone. So `lint-and-format`, `package-validation` and `test-electron-compatibility` were effectively advisory: **a PR breaking any of them could merge.**

It now aggregates all four, reporting per-job so a failure names the culprit:

```
needs: [test, lint-and-format, test-electron-compatibility, package-validation]
```

`security-audit` is deliberately excluded — its steps are `continue-on-error` and it is advisory by design.

> **The job name is intentionally unchanged.** Branch protection matches required checks *by name*; renaming `Build and Test` would silently disable the gate rather than fail loudly. Worth knowing before anyone tidies it.

## 2. Node 20 is end-of-life

Node 20 reached EOL in **April 2026** but was still the CI floor. Moved to the two supported LTS lines:

| Workflow | Before | After |
|---|---|---|
| `ci.yml` matrix | `20.x, 22.x` | `22.x, 24.x` |
| `release.yml` matrix | `20.9.0, 20.x, 22.x` | `22.12.0, 22.x, 24.x` |
| Standalone job pins | `20.x` | `24.x` (matches `publish.yml`) |

`22.12.0` is the first 22.x LTS release, keeping a pinned-floor leg.

## 3. The Electron annotations from the dispatched release run

`release.yml`'s Electron matrix had a `Display Electron version info` step running `npx electron --version`. That aborts on **every Linux leg**:

```
FATAL:setuid_sandbox_host.cc(158) The SUID sandbox helper binary was found,
but is not configured correctly... chrome-sandbox must be owned by root, mode 4755
```

`npm install` cannot set that ownership. `continue-on-error: true` kept the job green while GitHub still recorded a failure annotation per ubuntu leg — 7 on the last run, 11 before the matrix was resized. It is **pre-existing**, not introduced by #23.

The step was diagnostic-only, and wrong besides: its second line ran *plain Node*, not Electron, so it printed the runner's Node version under the label `Node in Electron` — it never reported what it claimed to, even where it didn't crash. Removed.

Also added `--ignore-scripts` to that job's Electron install, mirroring `ci.yml`. The job only typechecks against the bundled `electron.d.ts`, so downloading a ~100MB binary across all 21 legs was pure latency.

## 4. Dead step removed

`ci.yml` ran `npx audit-ci --config-type audit-resolve.json`. That file does not exist in this repo, `audit-ci` is not a devDependency, and between `|| echo` and `continue-on-error` the step could not fail. It has never done anything.

## 5. `AGENTS.md` no longer ships to npm

It is agent guidance, not consumer documentation, and was adding 6.8kB to every tarball. Published contents now: `dist/`, the four root shims, `README.md`, `LICENSE` — 45 files, 20.3 kB.

## Verification

Build clean, **129/129 tests pass**, all workflows parse, `npm pack --dry-run` confirms `AGENTS.md` is gone.

Note that this PR's own CI run is the first exercise of the widened `Build and Test` gate.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QaFZnzG9QNzXXkUTvQprDs