### PR TITLE
chore: ignore @types/node major bumps in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -44,6 +44,15 @@ updates:
       # Ignore major version updates for Electron (require manual review)
       - dependency-name: "electron"
         update-types: ["version-update:semver-major"]
+      # @types/node is held at ^24 on purpose. The peer floor is electron >=25,
+      # whose bundled Node is far older than current; types newer than the
+      # oldest supported runtime let code compile here against APIs that are
+      # absent for consumers on older Electron. This is build-time only — the
+      # generated .d.ts files reference no Node types — so newer types buy
+      # nothing. Revisit deliberately alongside the Electron peer floor rather
+      # than on Dependabot's weekly schedule.
+      - dependency-name: "@types/node"
+        update-types: ["version-update:semver-major"]
 
   # Enable security updates for GitHub Actions
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
Stops Dependabot re-proposing `@types/node` majors. Follow-up to #23, where `^24` was chosen deliberately.

## Why pin

The peerDependency floor is `electron >=25.0.0`, and the Node bundled in that Electron is far older than current. Types newer than the oldest supported runtime let code in this repo compile against APIs that are simply absent for consumers on older Electron — the compiler stops being a guardrail for the floor we advertise.

The dependency is build-time only: the generated `.d.ts` files reference no Node types (verified in #23), so consumers never see it and newer types buy nothing in return.

## Why an ignore rule rather than just closing the PR

Closing alone doesn't hold. Dependabot re-proposes the bump on its weekly run — #25 (`24.13.3` → `26.1.2`) was the latest — which means re-making the same decision indefinitely. The rule records the reasoning where it will actually be read.

```yaml
- dependency-name: "@types/node"
  update-types: ["version-update:semver-major"]
```

Minor and patch updates still flow normally through the `dev-dependencies` group. This mirrors the existing rule for `electron` majors.

Revisit alongside the Electron peer floor, not on Dependabot's schedule.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QaFZnzG9QNzXXkUTvQprDs