### PR TITLE
fix: allow ESM consumers to import the package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -230,6 +230,27 @@ jobs:
             }
           "
 
+          # And that it can be imported from ESM. The require() check above
+          # passed for months while `import` failed outright with
+          # ERR_PACKAGE_PATH_NOT_EXPORTED, because package.json declared no
+          # `import` condition. Testing only one module system hid that
+          # completely — assert named exports actually resolve, since a default
+          # -only import would still succeed while breaking every real consumer.
+          node --input-type=module -e "
+            import { ApiKeyServiceMain } from 'genai-key-storage-lite';
+            import { ApiKeyServiceRenderer } from 'genai-key-storage-lite/renderer';
+            import { createApiKeyManagerBridge } from 'genai-key-storage-lite/preload';
+            import { ApiKeyStorageError } from 'genai-key-storage-lite/common';
+            const named = { ApiKeyServiceMain, ApiKeyServiceRenderer, createApiKeyManagerBridge, ApiKeyStorageError };
+            for (const [name, value] of Object.entries(named)) {
+              if (typeof value !== 'function') {
+                console.error('❌ ESM named export missing or wrong type:', name, typeof value);
+                process.exit(1);
+              }
+            }
+            console.log('✅ ESM imports work correctly');
+          "
+
   # This job is the single required status check in branch protection on main.
   # Keep the name "Build and Test" stable — renaming it silently disables the
   # gate, because branch protection matches required checks by name.

--- a/README.md
+++ b/README.md
@@ -29,7 +29,16 @@ yarn add genai-key-storage-lite
 
 Electron is a peer dependency, declared as `>=25.0.0`. CI typechecks the library against Electron 25.x (the floor), 39.x, and 43.x on every pull request, and samples every third major from 25.x through 43.x on release.
 
-The package ships CommonJS targeting ES2021. Its type declarations reference no Node.js types, so your project's `@types/node` version is unconstrained by this package.
+The package ships CommonJS targeting ES2021, and every export is usable from both CommonJS and ES modules:
+
+```js
+const { ApiKeyServiceMain } = require("genai-key-storage-lite"); // CommonJS
+import { ApiKeyServiceMain } from "genai-key-storage-lite"; // ES modules
+```
+
+Both conditions resolve to the same file, so there is only ever one instance of the module — `instanceof` checks and module state stay consistent regardless of how a consumer imports it.
+
+Its type declarations reference no Node.js types, so your project's `@types/node` version is unconstrained by this package.
 
 ## Available Exports
 

--- a/package.json
+++ b/package.json
@@ -29,20 +29,24 @@
   "types": "./dist/main/index.d.ts",
   "exports": {
     ".": {
-      "require": "./dist/main/index.js",
-      "types": "./dist/main/index.d.ts"
+      "types": "./dist/main/index.d.ts",
+      "import": "./dist/main/index.js",
+      "require": "./dist/main/index.js"
     },
     "./renderer": {
-      "require": "./dist/renderer/index.js",
-      "types": "./dist/renderer/index.d.ts"
+      "types": "./dist/renderer/index.d.ts",
+      "import": "./dist/renderer/index.js",
+      "require": "./dist/renderer/index.js"
     },
     "./preload": {
-      "require": "./dist/preload/index.js",
-      "types": "./dist/preload/index.d.ts"
+      "types": "./dist/preload/index.d.ts",
+      "import": "./dist/preload/index.js",
+      "require": "./dist/preload/index.js"
     },
     "./common": {
-      "require": "./dist/common/index.js",
-      "types": "./dist/common/index.d.ts"
+      "types": "./dist/common/index.d.ts",
+      "import": "./dist/common/index.js",
+      "require": "./dist/common/index.js"
     }
   },
   "scripts": {


### PR DESCRIPTION
ESM consumers could not import this package at all. Every subpath declared only `require` and `types`, so `import` failed outright:

```
ERR_PACKAGE_PATH_NOT_EXPORTED
```

Electron projects on Vite or electron-vite default to ESM, so this hit real consumers on their first import.

## The fix

An `import` condition pointing at **the same CommonJS file** already served to `require`, with `types` moved first so it is matched before the runtime conditions:

```json
".": {
  "types": "./dist/main/index.d.ts",
  "import": "./dist/main/index.js",
  "require": "./dist/main/index.js"
}
```

**Why one file matters.** The dual-package hazard comes from shipping *two* copies of a module, so `instanceof` checks and module state diverge across the CJS/ESM boundary. With both conditions resolving to a single file that cannot arise. No ESM build, no `.mjs`, no duplicated code — 12 lines of `package.json`.

**Why named exports survive.** TypeScript's CommonJS output uses `exports.X = void 0` followed by `Object.defineProperty(exports, ...)`, which is exactly the shape Node's `cjs-module-lexer` detects. So ESM gets real named imports, not just a default.

## Verified against the packed tarball

Not against the source tree — against `npm pack` output installed into a clean project, which is what consumers actually get:

| | Result |
|---|---|
| CJS `require`, all four subpaths | ✅ unchanged |
| ESM `import { ... }`, all four subpaths | ✅ named exports resolve |
| Test suite | ✅ 129/129 |

## Regression guard

Added an ESM smoke test to `package-validation`. The existing `require()` check passed for months while `import` was broken — testing one module system hid the gap completely. The new check asserts **named** exports resolve, because a default-only import would still succeed while breaking every real consumer.

This also makes that job's pre-existing `config.import` assertion live rather than dead code: it had nothing to check while no `import` condition existed.

## Known limitation

Strict packaging linters (`arethetypeswrong`) will note that ESM resolution lands on a CommonJS `.d.ts`. Fixing that properly needs real `.d.mts` + `.mjs` outputs — a materially larger change, and not worth it to silence a cosmetic warning when the runtime failure is what affected users.

## Docs

README gains a short note that both module systems work, replacing what would otherwise have been a paragraph documenting the limitation.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QaFZnzG9QNzXXkUTvQprDs