### PR TITLE
chore(release): 0.1.14

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "genai-key-storage-lite",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "genai-key-storage-lite",
-      "version": "0.1.13",
+      "version": "0.1.14",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^30.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "genai-key-storage-lite",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "description": "A secure API key storage module for Electron generative AI based applications using native OS credential stores.",
   "keywords": [
     "electron",


### PR DESCRIPTION
Patch bump so the ESM fix from #28 can actually reach npm.

## Why this is required, not optional

The registry currently serves **0.1.13**, and its exports map has no `import` condition — so every ESM consumer still fails with `ERR_PACKAGE_PATH_NOT_EXPORTED` no matter what has landed on `main`.

`publish.yml` reads the version from `package.json` and **skips publishing when that version already exists** (`publish.yml:52-56`). Dispatched against 0.1.13 it would:

1. log `Version 0.1.13 is already published to npm - skipping publish`
2. skip the GitHub release too, since `v0.1.13` is already tagged
3. **finish green having shipped nothing**

So without this bump the fix stays invisible to users while every signal reads healthy.

## Consumer-visible changes since 0.1.13

- **ESM imports resolve** across all four subpaths (#28) — the reason for this release
- **`AGENTS.md` no longer ships** in the tarball (#26)
- **README** documents the supported Electron range and both module systems

Everything else merged since 0.1.13 (#23, #26, #27) was CI and repository tooling with no effect on the published artifact.

## Why patch, not minor

This repairs packaging that was broken for ESM consumers rather than adding a capability. `0.2.0` would be defensible if you want to advertise ESM support as a feature — say so and I'll change it before merge.

## Verification

Version updated consistently in `package.json` and both `package-lock.json` fields. Build clean, 129/129 tests pass, tarball builds as `genai-key-storage-lite@0.1.14` (45 files, 20.5 kB). No git tag was created locally — `publish.yml` owns tagging.

## After merge

Publishing still requires a **manual `workflow_dispatch` of `publish.yml`** — merging this does not release anything.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QaFZnzG9QNzXXkUTvQprDs