### PR TITLE
fix: export the ./package.json subpath

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -251,6 +251,23 @@ jobs:
             console.log('✅ ESM imports work correctly');
           "
 
+          # Tooling that reads a dependency's manifest needs ./package.json to
+          # be exported explicitly; an exports map without it makes the file
+          # unreachable even though it is present in the tarball.
+          node -e "
+            try {
+              const manifest = require('genai-key-storage-lite/package.json');
+              if (!manifest.version) {
+                console.error('❌ package.json subpath resolved but has no version');
+                process.exit(1);
+              }
+              console.log('✅ package.json subpath is reachable:', manifest.version);
+            } catch (error) {
+              console.error('❌ package.json subpath not exported:', error.message);
+              process.exit(1);
+            }
+          "
+
   # This job is the single required status check in branch protection on main.
   # Keep the name "Build and Test" stable — renaming it silently disables the
   # gate, because branch protection matches required checks by name.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "genai-key-storage-lite",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "genai-key-storage-lite",
-      "version": "0.1.14",
+      "version": "0.1.15",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^30.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "genai-key-storage-lite",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "description": "A secure API key storage module for Electron generative AI based applications using native OS credential stores.",
   "keywords": [
     "electron",
@@ -47,7 +47,8 @@
       "types": "./dist/common/index.d.ts",
       "import": "./dist/common/index.js",
       "require": "./dist/common/index.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "scripts": {
     "build": "tsc",


### PR DESCRIPTION
`require('genai-key-storage-lite/package.json')` failed with `ERR_PACKAGE_PATH_NOT_EXPORTED`. Found while verifying the 0.1.14 release from the registry.

## What's wrong

An `exports` map makes every subpath **not** listed in it unreachable. `package.json` ships in the tarball, but without an entry it cannot be resolved — which breaks bundler plugins and framework tooling that read a dependency's manifest for its version or metadata.

The conventional fix:

```json
"./package.json": "./package.json"
```

**This predates #28** — the exports map has never listed it — so it isn't a regression from the ESM work.

## Regression guard

Added to `package-validation`, alongside the CJS and ESM smoke tests added in #28. That job's existing export-file loop only inspects object-valued conditions, so the new string-valued entry is skipped by it and the loop is unaffected — verified.

## Version bump to 0.1.15

Included deliberately. `publish.yml` skips any version already on the registry, so a packaging fix **cannot reach consumers without a new version** — leaving it out would mean the fix sits on `main` doing nothing, which is exactly the trap we hit with 0.1.13. Happy to split it out if you'd rather batch this with other work.

**Merging still publishes nothing** — releasing remains a manual `workflow_dispatch` of `publish.yml`.

## Verification

Against the packed tarball installed into a clean project:

| Path | Result |
|---|---|
| `require('.../package.json')` | ✅ resolves to `genai-key-storage-lite@0.1.15` |
| CJS `require` | ✅ unchanged |
| ESM `import` | ✅ unchanged |

Build clean, 129/129 tests pass.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QaFZnzG9QNzXXkUTvQprDs